### PR TITLE
feat(writeShellApplication): highlighted ide-check diagnostics + nu-check linter

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -242,6 +242,10 @@
             ${pkgs.nushell}/bin/nu --env-config ${./nuenv/user-env.nu} --commands "nuenvCommands"
           '';
 
+          nu-check = pkgs.writeShellScriptBin "nu-check" ''
+            exec ${pkgs.nushell}/bin/nu --no-config-file ${./nuenv/ide-check.nu} "$@"
+          '';
+
           # For NixCon
           hello = pkgs.nuenv.mkDerivation {
             name = "hello-nix-nushell";

--- a/lib/writeShellApplication.nix
+++ b/lib/writeShellApplication.nix
@@ -46,9 +46,14 @@ in
   */
   meta ? { },
   /*
-    The `checkPhase` to run. Defaults to `nu-check`.
+    The `checkPhase` to run. Defaults to statically checking the source with
+    `nu --ide-check` (the shellcheck analogue), failing the build on any error
+    the compiler can prove without running the code and rendering a highlighted
+    context block for each.
 
-    The script path will be given as `$target` in the `checkPhase`.
+    The assembled script path is given as `$target`, and the raw, unwrapped
+    source (`text`) as `$nuSource`; the default check runs against `$nuSource` so
+    it validates your code, not the generated wrapper.
 
     Type: String
   */
@@ -78,6 +83,21 @@ in
   */
   nushellArgs ? [ "--stdin" ],
 }:
+let
+  # The raw, unwrapped source (no shebang / injected env / PATH), so the check
+  # validates the user's code rather than the generated wrapper.
+  nuSource = writeTextFile {
+    name = "${name}-source.nu";
+    inherit text;
+  };
+
+  nu = lib.getExe nushellPackage;
+
+  # The shared linter (also exposed as the `nu-check` package), so the build
+  # check and the CLI share one implementation. Self-contained via
+  # `$nu.current-exe`.
+  nuIdeCheck = ../nuenv/ide-check.nu;
+in
 writeTextFile {
   inherit name meta derivationArgs;
   executable = true;
@@ -102,12 +122,21 @@ writeTextFile {
     '';
 
   checkPhase =
+    let
+      # Exposed to custom checkPhases as well.
+      nuSourceEnv = "nuSource=${nuSource}";
+    in
     if checkPhase == null then
       ''
         runHook preCheck
-        ${lib.getExe nushellPackage} --commands "nu-check --debug '$target'"
+        ${nuSourceEnv}
+        # Static check; fails the build with highlighted context on any error.
+        ${nu} --no-config-file ${nuIdeCheck} ${nuSource}
         runHook postCheck
       ''
     else
-      checkPhase;
+      ''
+        ${nuSourceEnv}
+        ${checkPhase}
+      '';
 }

--- a/nuenv/ide-check.nu
+++ b/nuenv/ide-check.nu
@@ -1,0 +1,101 @@
+# Statically check Nushell files (`nu --ide-check`) and print each error as a
+# highlighted context block with a red undercurl under the span — the shellcheck
+# analogue for `writeShellApplication`. Catches what the compiler can prove
+# without running the code (syntax, command signatures, static type errors,
+# unknown vars); not data-dependent errors or unknown externals. `ide-check`
+# always exits 0, so we read its diagnostics and exit non-zero ourselves.
+#
+# Usage: nu ide-check.nu FILE...
+
+# Wrap visible columns [start0, start0 + len) of an already-highlighted line
+# with a red undercurl. Escapes pass through; each underlined char is wrapped
+# individually so an interior `nu-highlight` reset can't cancel it. A zero-width
+# or past-end span underlines a trailing space.
+def undercurl [hl: string, start0: int, len: int] {
+  let esc = (char --unicode "1b")
+  let on = $"($esc)[4:3m($esc)[58:2:255:0:0m"
+  let off = $"($esc)[24m($esc)[59m"
+  mut out = ""
+  mut vis = 0
+  mut inesc = false
+  for ch in ($hl | split chars) {
+    if $inesc {
+      $out = $out + $ch
+      if $ch == "m" { $inesc = false }
+    } else if $ch == $esc {
+      $out = $out + $ch
+      $inesc = true
+    } else {
+      if ($vis >= $start0 and $vis < ($start0 + $len)) {
+        $out = $out + $on + $ch + $off
+      } else {
+        $out = $out + $ch
+      }
+      $vis = $vis + 1
+    }
+  }
+  if ($vis <= $start0) { $out = $out + $on + " " + $off }
+  $out
+}
+
+# Statically check a single file, printing a diagnostic block per error.
+# Returns the number of errors found.
+def check-file [src: string] {
+  if not ($src | path exists) {
+    print -e $"(ansi red_bold)error:(ansi reset) no such file: ($src)"
+    return 1
+  }
+
+  let res = (^$nu.current-exe --ide-check 100 $src | complete)
+  let diags = (
+    $res.stdout
+    | lines
+    | where ($it | str trim) != ""
+    | each {|l| $l | from json }
+    | where type == "diagnostic" and severity == "Error"
+  )
+  if ($diags | is-empty) { return 0 }
+
+  let bytes = (open --raw $src | into binary)
+  # Syntax-highlighted source, split into lines for context display.
+  let hl = (open --raw $src | nu-highlight | lines)
+  let total = ($hl | length)
+
+  for d in $diags {
+    let off = $d.span.start
+    # Map the byte offset to 1-based line/column via the preceding bytes.
+    let prefix = ($bytes | bytes at ..<$off | decode utf-8)
+    let segs = ($prefix | split row "\n")
+    let lineno = ($segs | length)
+    let col = (($segs | last | str length) + 1)
+    let spanlen = ([($bytes | bytes at $off..<($d.span.end) | decode utf-8 | str length) 1] | math max)
+
+    let from = ([($lineno - 1) 1] | math max)
+    let to = ([($lineno + 1) $total] | math min)
+    let gw = ($to | into string | str length)
+
+    print -e $"(ansi blue)($src):($lineno):($col)(ansi reset)"
+    for n in $from..$to {
+      let g = ($n | into string | fill --alignment right --width $gw)
+      let t = ($hl | get ($n - 1))
+      if $n == $lineno {
+        # Offending line: red gutter + inline red undercurl under the span.
+        print -e $"(ansi red_bold)($g)(ansi reset) (ansi grey)│(ansi reset) (undercurl $t ($col - 1) $spanlen)"
+      } else {
+        print -e $"(ansi grey)($g) │(ansi reset) ($t)"
+      }
+    }
+    print -e $"(ansi red_bold)error:(ansi reset) ($d.message)\n"
+  }
+
+  $diags | length
+}
+
+def main [...files: string] {
+  if ($files | is-empty) {
+    print -e "usage: nu-check FILE..."
+    exit 2
+  }
+  let errors = ($files | each {|f| check-file $f } | math sum)
+  if $errors > 0 { exit 1 }
+}


### PR DESCRIPTION
Statically checks Nushell at build time — the analogue of shellcheck in `writeShellApplication` — and exposes the same check as a standalone CLI linter.

## What this adds

- **Build-time check.** `nuenv.writeShellApplication` now statically checks the raw source with `nu --ide-check` and **fails the build on any error**, rendering a syntax-highlighted context block (offending line + the lines above/below, via `nu-highlight`) with a real **red curly underline (undercurl)** drawn directly under the offending span, and the message beneath.
- **Shared implementation.** The checker lives in `nuenv/ide-check.nu`, self-contained (uses `$nu.current-exe`), so the builder and the CLI share one implementation.
- **`nu-check` linter package.** Run the same check on any file(s):
  ```
  nix run .#nu-check -- FILE...
  ```
  Colour survives here because `nix run` writes to your terminal (Nix sanitizes ANSI out of *build* logs, so build failures show the diagnostic in plain text unless viewed via `nix log`).

## What `nu --ide-check` catches

It runs Nushell's static analysis (the parse + compile pass before execution), so it flags anything the compiler can prove wrong **without running the code**:

- syntax errors
- command signatures — unknown flags, wrong/missing positional args
- statically-decidable type errors — annotation & literal mismatches, operator type compatibility
- unknown variables

It does **not** do whole-program type inference, so data-dependent errors and unknown bare commands (treated as possible externals) are not flagged.

## Behaviour
- Exits non-zero if any file has an error; `0` if all clean.
- Handles multiple files, missing files, and zero-width / end-of-line spans (underlines a trailing space).
- Undercurl + underline-colour need a capable terminal (kitty, WezTerm, foot, Ghostty, iTerm2, recent VTE); others fall back to a straight underline.

## Verified
- `writeShellApplication`: valid builds; single/multi-error fails with the highlighted block.
- `nu-check`: build + `nix run` on broken (exit 1, coloured) and valid (exit 0) files, plus missing-file and no-arg usage paths.
- Real-world: built an entire NixOS system whose ~35 `writeNuApplication` packages all pass the check under nushell 0.113.1; a deliberately-broken one correctly fails the build.