### PR TITLE
Add CI check rejecting conventional-commit PR titles

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,0 +1,34 @@
+name: "PR title"
+
+# We merge PRs with merge commits and keep Conventional-Commit *branch* commits
+# (which drive release-please's changelog). GitHub echoes the PR title into the
+# merge commit, and release-please doesn't dedup — so a Conventional-Commit PR
+# title gets counted a second time, duplicating the changelog entry. Enforce
+# plain-English PR titles; the branch commits remain the single source of truth.
+
+on:
+  pull_request:
+    types:
+      - "opened"
+      - "edited"
+      - "reopened"
+      - "synchronize"
+
+permissions: {}
+
+jobs:
+  no-conventional-title:
+    # release-please's own release PR is titled "chore(main): release ..." on
+    # purpose — never lint that one.
+    if: "!startsWith(github.event.pull_request.head.ref, 'release-please--')"
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Reject Conventional-Commit PR titles"
+        env:
+          TITLE: "${{ github.event.pull_request.title }}"
+        run: |
+          if printf '%s\n' "$TITLE" | grep -qiE '^[[:space:]]*(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([^)]*\))?!?:'; then
+            echo "::error::PR title looks like a Conventional Commit: \"$TITLE\". Use a plain-English title (e.g. \"Add nu-check linter\") — merge commits echo the PR title into the release changelog, so a conventional title double-counts with your branch commits."
+            exit 1
+          fi
+          echo "OK: \"$TITLE\" is not a Conventional-Commit prefix."


### PR DESCRIPTION
Adds a lightweight `pull_request` check that fails when a PR title uses a Conventional-Commit prefix (`feat:`, `fix(x):`, `chore!:`, …).

## Why
We merge with **merge commits** and keep **Conventional-Commit branch commits** (which drive release-please's changelog). GitHub echoes the PR title into the merge commit, and release-please does not dedup — so a conventional PR title is counted a second time, duplicating the changelog entry (as happened for the 1.3.0 release before the history rewrite).

This check enforces the rule that keeps it clean: **plain-English PR titles; conventional branch commits.**

## Details
- Runs on `opened`/`edited`/`reopened`/`synchronize`.
- **Exempts** the release-please branch (`release-please--*`), whose title is intentionally `chore(main): release …`.
- `permissions: {}` — reads only the title from the event payload (passed via env, no injection).

This PR's own title is plain English, so the new check passes on itself.